### PR TITLE
Make the Design System hostable with Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run serve-static -- --port $PORT

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prestart": "node bin/check-nvmrc.js",
     "build": "node tasks/build.js",
     "start": "node tasks/serve.js",
+    "serve-static": "node tasks/serve-static.js",
     "test": "npm run lint && jest",
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "standard",

--- a/tasks/serve-static.js
+++ b/tasks/serve-static.js
@@ -1,0 +1,19 @@
+const http = require('http')
+const connect = require('connect')
+const serveStatic = require('serve-static')
+
+const paths = require('../config/paths.json')
+
+if (process.argv.length != 4 || process.argv[2] != "--port") {
+  console.error("--port <port> must be specified");
+  process.exit(1);
+}
+
+const port = process.argv[3];
+
+// Create a simple server for serving static files
+const app = connect().use(serveStatic(paths.public))
+console.log("Serving static site using existing build.")
+http.createServer(app).listen(port, () => {
+  console.log(`Listening on port ${port}...`)
+})


### PR DESCRIPTION
The `start` npm task tries to run the development version of the site,
which requires that the devDependencies be installed. Heroku prunes
these dependencies upon build, so they aren’t available and trying to
access the site gives an error. So instead, we add a new `serve-static`
task for Heroku to run, which uses the prebuilt site that was built
during the push to Heroku.

The code is pretty much copied from tasks/test-serve.js.