### PR TITLE
School search page improvements

### DIFF
--- a/src/patterns/school-search/error-empty-field/index.njk
+++ b/src/patterns/school-search/error-empty-field/index.njk
@@ -30,7 +30,6 @@ title: Error, empty field – School search
         {{ govukButton({
           text: "Save and continue"
         }) }}
-
     </div>
   </div>
 {% endblock %}

--- a/src/patterns/school-search/index.md.njk
+++ b/src/patterns/school-search/index.md.njk
@@ -55,17 +55,20 @@ Say ‘Enter the name or postcode of the school’.
 
 Say ‘No results match that search term. Try again.’
 
+### Non-javascript version
+
+Accessible autocomplete is a progressive enchancement, you will need to create
+a non-javascript version of your search. This should include all the same
+features and information.
+
+{{ example({group: "patterns", item: "school-search", example: "with-search-results", html: true, nunjucks: true, open: false, size: "xl"}) }}
+
 ## Research on this pattern
 
 Research on this pattern is limited. We've done some testing which indicates it
 is usable and accessible, but we've also included an option for users who are
 unable to use JavaScript.
 
-### Without javascript search results option
-
-When users are unable to use JavaScript search results should be styled like this:
-
-{{ example({group: "patterns", item: "school-search", example: "with-search-results", html: true, nunjucks: true, open: false, size: "xl"}) }}
 
 ### Employed to teach vs employed at
 

--- a/src/patterns/school-search/with-search-results/index.njk
+++ b/src/patterns/school-search/with-search-results/index.njk
@@ -13,7 +13,6 @@ title: With search results - school search non-JS fallback
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">Which school are you employed to teach at?</h1>
 
-
         {{ govukInput({
           hint: {
             text: "Enter the school name or postcode. Use at least three characters."


### PR DESCRIPTION
This PR will move the non-js version out of the research section and fix some code formatting on the examples used.

Non-js section is now after errors and before the research sections.
![image](https://user-images.githubusercontent.com/13239597/78122602-e93cf980-7404-11ea-84b9-badd9242db43.png)
