### PR TITLE
Fixes to student loan page

### DIFF
--- a/src/patterns/student-loan-amount/default/index.njk
+++ b/src/patterns/student-loan-amount/default/index.njk
@@ -5,7 +5,6 @@ title: Default – Student loan amount
 
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-
 <h1 class="govuk-label-wrapper">
   <label class="govuk-label govuk-label--xl" for="student-loan-amount">
     Exactly how much student loan did you repay while employed as a teacher between 6 April 2018 and 5 April 2019?

--- a/src/patterns/student-loan-amount/index.md.njk
+++ b/src/patterns/student-loan-amount/index.md.njk
@@ -3,7 +3,8 @@ title: Student loan amount
 description: Ask users how much student loan they repaid in a given timeframe
 section: Patterns
 theme: Ask users for…
-aliases: loan amount, student loan
+aliases: loan amount, student loan, loan, amount, student
+backlog_issue_id: 68
 layout: layout-pane.njk
 ---
 
@@ -29,6 +30,13 @@ and have specific error messages for specific error states.
 
 #### If nothing has been entered
 
+Say 'Enter your student loan repayment amount'.
+
 #### If the incorrect amount of characters have been entered
 
+Say 'Value must be less than 99999'.
+
 ## Research on this pattern
+
+This pattern is based on the proposed [Currency input](https://github.com/alphagov/govuk-design-system-backlog/issues/68)
+in the design system community backlog.


### PR DESCRIPTION
- Add in backlog issues ID for currency input
- Explicitly link to currency input page for research section
- Add in missing error messages