### PR TITLE
Disciplinary action

### DIFF
--- a/src/patterns/subject-to-disciplinary-action/default/index.njk
+++ b/src/patterns/subject-to-disciplinary-action/default/index.njk
@@ -8,8 +8,8 @@ layout: layout-example.njk
 
 {{ govukRadios({
   classes: "govuk-radios--inline",
-  idPrefix: "changed-name",
-  name: "changed-name",
+  idPrefix: "disciplinary-action",
+  name: "disciplinary-action",
   fieldset: {
     legend: {
       text: "Are you subject to disciplinary action?",

--- a/src/patterns/subject-to-disciplinary-action/error-none-selected/index.njk
+++ b/src/patterns/subject-to-disciplinary-action/error-none-selected/index.njk
@@ -8,8 +8,8 @@ layout: layout-example.njk
 
 {{ govukRadios({
   classes: "govuk-radios--inline",
-  idPrefix: "changed-name",
-  name: "changed-name",
+  idPrefix: "disciplinary-action",
+  name: "disciplinary-action",
   fieldset: {
     legend: {
       text: "Are you subject to disciplinary action?",

--- a/src/patterns/subject-to-disciplinary-action/index.md.njk
+++ b/src/patterns/subject-to-disciplinary-action/index.md.njk
@@ -3,8 +3,7 @@ title: Disciplinary action information
 description: Ask users if they are currently subject to any disciplinary action
 section: Patterns
 theme: Ask users for…
-aliases: radio buttons, option buttons, ITT
-backlog_issue_id: 59
+aliases: disciplinary action, formal investigation, warning
 layout: layout-pane.njk
 ---
 
@@ -16,8 +15,6 @@ layout: layout-pane.njk
 
 Use this pattern when you need to ask a teacher if they are currently subject to
 disciplinary action.
-
-## When not to use this pattern
 
 ### Error messages
 
@@ -35,12 +32,19 @@ and have specific error messages for specific error states.
 
 ## Provide more information on the ineligible screen
 
-It's possible that a user's disciplinary
-action will be reovked before the dealine for a service. You should tell users this
-deadline if your service is not open all year round.
+It's possible that a user's disciplinary action will be revoked before the
+deadline for a service. You should tell users this deadline if your service is
+not open all year round.
 
 ## Say that we only use this for eligibility
 
 Users may be concerned that we'll store this information or use it against them in some way.
 
 ## Research on this component
+
+Some users struggled with this question indicating that there could be an initial
+informal investigation before formal disciplinary action was taken.
+
+Users were also worried that they would be added to a list that would be used
+for other purposes. When asking this question we recommend that you clearly
+state how this information will be used.


### PR DESCRIPTION
- remove incorrect backlog backlog_issue_id
- appropriate search aliases
- remove when not to use this pattern as we have no examples
- add in learning for user research sessions
- fix incorrect IDs on code examples