### PR TITLE
Itt date improvements

### DIFF
--- a/src/patterns/when-did-you-complete-ITT/default/index.njk
+++ b/src/patterns/when-did-you-complete-ITT/default/index.njk
@@ -8,8 +8,8 @@ layout: layout-example.njk
 
 {{ govukRadios({
   classes: "govuk-radios--inline",
-  idPrefix: "changed-name",
-  name: "changed-name",
+  idPrefix: "ITT-date",
+  name: "ITT-date",
   fieldset: {
     legend: {
       text: "When did you complete your initial teacher training?",
@@ -30,5 +30,5 @@ layout: layout-example.njk
 }) }}
 
 {{ govukButton({
-          text: "Continue"
-        }) }}
+  text: "Continue"
+}) }}

--- a/src/patterns/when-did-you-complete-ITT/error-none-selected/index.njk
+++ b/src/patterns/when-did-you-complete-ITT/error-none-selected/index.njk
@@ -8,8 +8,8 @@ layout: layout-example.njk
 
 {{ govukRadios({
   classes: "govuk-radios--inline",
-  idPrefix: "changed-name",
-  name: "changed-name",
+  idPrefix: "ITT-date",
+  name: "ITT-date",
   errorMessage: {
     text: "Select when you completed your initial teacher training"
   },
@@ -33,5 +33,5 @@ layout: layout-example.njk
 }) }}
 
 {{ govukButton({
-          text: "Continue"
-        }) }}
+  text: "Continue"
+}) }}

--- a/src/patterns/when-did-you-complete-ITT/index.md.njk
+++ b/src/patterns/when-did-you-complete-ITT/index.md.njk
@@ -3,8 +3,7 @@ title: Initial Teacher Training qualification year
 description: Ask users if they completed their initial teacher training before or after a specific date
 section: Patterns
 theme: Ask users for…
-aliases: radio buttons, option buttons, ITT
-backlog_issue_id: 59
+aliases: ITT, initial teacher training, qualification year, QTS, QTLS, NQT
 layout: layout-pane.njk
 ---
 
@@ -14,7 +13,21 @@ layout: layout-pane.njk
 
 ## When to use this pattern
 
+Use this pattern when a teacher is eligible for your service if they completed
+their initial teacher training before or after a specific date.
+
 ## When not to use this pattern
+
+Do not use this pattern when you need to ask the exact date a  teacher completed
+their initial teacher training.
+
+## How it works
+
+When asking when the teacher completed their initial teacher training:
+
+- do not use the initialism ITT (Initial Teacher Training) which is common
+within DfE
+- use radios and list the options in academic years rather than a specific date
 
 ### Error messages
 
@@ -22,10 +35,17 @@ Error messages should be styled like this:
 
 {{ example({group: "patterns", item: "when-did-you-complete-ITT", example: "error-none-selected", html: true, nunjucks: true, open: false, size: "s"}) }}
 
-Make sure errors follow the guidance in the GDS
-[error message component](https://design-system.service.gov.uk/components/error-message/)
-and have specific error messages for specific error states.
+#### If the user does not select an academic year
+
+Say ‘Select when you completed your initial teacher training’.
 
 ## Research on this component
 
-### Teachers work in academic years
+Whilst developing this pattern we have looked into:
+
+- how to best ask this question using specific dates or acadmeic years. Whilst
+academic years might be harder for us to understand they make sense to
+teachers.
+- whilst there are several different ways to get into teaching, each with
+different qualifications the catch all term 'Initial teacher training' was the
+most easily understood


### PR DESCRIPTION
- remove backlog id
- add relevant aliases for search
- add content explaining when to/not to use this pattern
- add content explaining how the pattern works
- add error message content for when no option is selected
- add research section explaining that teacher like to think in academic
years and that whilst Initial Teacher Training might not be the most
accurate term, it is universally understood.
- Improve formatting on code examples