### PR TITLE
Subjects taught improvements

### DIFF
--- a/src/patterns/which-subjects-do-you-teach/error-none-selected/index.njk
+++ b/src/patterns/which-subjects-do-you-teach/error-none-selected/index.njk
@@ -3,61 +3,53 @@ title: Error, none selected – Which of the following subjects did you teach at
 layout: layout-example.njk
 ---
 
-{% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+<div class="govuk-form-group govuk-form-group--error">
+  <fieldset class="govuk-fieldset" id="claim_subjects_taught">
 
-{{ govukCheckboxes({
-  idPrefix: "subjectsTaught",
-  name: "subjectsTaught",
-  fieldset: {
-    legend: {
-      text: "Which subjects do you teach?",
-      isPageHeading: true,
-      classes: "govuk-fieldset__legend--xl"
-    }
-  },
-  errorMessage: {
-    text: "Which subjects do you teach?"
-  },
-  items: [
-    {
-      value: "Biology",
-      text: "Biology"
-    },
-    {
-      value: "Chemistry",
-      text: "Chemistry"
-    },
-    {
-      value: "Physics",
-      text: "Physics"
-    },
-    {
-      value: "Computing",
-      text: "Computing"
-    },
-    {
-      value: "Languages",
-      text: "Languages"
-    }
-  ]
-}) }}
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-fieldset__heading">
+        Which of the following subjects did you teach at Penistone Grammar School between 6 April 2018 and 5 April 2019?
+      </h1>
+    </legend>
 
-{{ govukRadios({
-  idPrefix: "subjectsTaught",
-  name: "subjectsTaught",
-  items: [
-    {
-      divider: "or"
-    },
-    {
-      value: "I did not teach any of these subjects",
-      text: "I did not teach any of these subjects"
-    }
-  ]
-}) }}
+    <span class="govuk-error-message" id="student_loans_eligibility_subjects_taught-error">
+      <span class="govuk-visually-hidden">Error:</span> Select if you taught Biology, Chemistry, Physics, Computing,
+      Languages or you did not teach any of these subjects</span>
+      <div class="govuk-checkboxes">
 
-{{ govukButton({
-  text: "Continue"
-}) }}
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input subject" id="biology_taught" type="checkbox" name="subjects_taught">
+          <label class="govuk-label govuk-checkboxes__label" for="biology_taught">Biology</label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input subject" id="chemistry_taught" type="checkbox" name="subjects_taught">
+          <label class="govuk-label govuk-checkboxes__label" for="chemistry_taught">Chemistry</label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input subject" id="physics_taught" type="checkbox" name="subjects_taught">
+          <label class="govuk-label govuk-checkboxes__label" for="physics_taught">Physics</label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input subject" id="computing_taught" type="checkbox" name="subjects_taught">
+          <label class="govuk-label govuk-checkboxes__label" for="computing_taught">Computing</label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input subject" id="languages_taught" type="checkbox" name="subjects_taught">
+          <label class="govuk-label govuk-checkboxes__label" for="languages_taught">Languages</label>
+        </div>
+
+        <div class="govuk-radios__divider">or</div>
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" type="radio" name="subjects_taught" id="none_taught">
+          <label class="govuk-label govuk-radios__label" for="none_taught">I did not teach any of these subjects</label>
+        </div>
+
+      </div>
+    </span>
+  </fieldset>
+</div>

--- a/src/patterns/which-subjects-do-you-teach/index.md.njk
+++ b/src/patterns/which-subjects-do-you-teach/index.md.njk
@@ -3,8 +3,7 @@ title: Subjects taught
 description: Ask users to select from a list of subjects or choose none
 section: Patterns
 theme: Ask users for…
-aliases: radio buttons, option buttons, ITT
-backlog_issue_id: 59
+aliases: subjects taught, subjects, what do you teach
 layout: layout-pane.njk
 ---
 
@@ -14,16 +13,33 @@ layout: layout-pane.njk
 
 ## When to use this pattern
 
+Use this pattern when a teacher is eligible for your service if they teach
+one or more of a small selection of subjects.
+
 ## When not to use this pattern
+
+Do not use this pattern when you need to ask a teacher what subjects they teach
+from a large selection of subjects. Instead consider alternative methods such
+as a [search option]{https://github.com/alphagov/govuk-design-system-backlog/issues/88}
+or [text input](https://design-system.service.gov.uk/components/text-input/).
+
+## How it works
+
+This is a unique pattern that requires the use of checkboxes, the or divider and
+a radio button in one question.
+
+- When a user selects one or more checkboxes, the radio button should be
+unselected.
+- When a user selects the radio button, all checkboxes should be unselected.
 
 ### Error messages
 
-Error messages should be styled like this:
-
 {{ example({group: "patterns", item: "which-subjects-do-you-teach", example: "error-none-selected", html: true, nunjucks: true, open: false, size: "s"}) }}
 
-Make sure errors follow the guidance in the GDS
-[error message component](https://design-system.service.gov.uk/components/error-message/)
-and have specific error messages for specific error states.
+#### If the user does not select any languages
 
-## Research on this component
+Say ‘Select if you taught Biology, Chemistry, Physics, Computing, Languages or
+you didn’t teach any of these subjects’.
+
+If you have a longer list of languages you may want to say 'Select which subjects
+you teach or select you didn’t teach any of these subjects'


### PR DESCRIPTION
- Add in the missing content to the subject taught page so that it is consistent with the rest of the pattern library. 
- Change the code example for the error to be HTML instead of nunjucks so that the red error highlight works as intended. As this is a combination of multiple question types I think it's fine to show it only as HTML.
- Add a section explaining how it works when users select inputs.