### PR TITLE
Remove unused sections from the index page

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -7,7 +7,6 @@ description: Reuse some patterns from the Claim additional payments for teaching
 <div class="app-width-container">
   <div class="govuk-main-wrapper govuk-main-wrapper--l">
     <div class="govuk-grid-row">
-
       <div class="govuk-grid-column-two-thirds-from-desktop">
         <h2 id="support" class="govuk-heading-l">Support</h2>
 
@@ -47,30 +46,58 @@ description: Reuse some patterns from the Claim additional payments for teaching
       </ul>
 
       </div>
-
-      <div class="govuk-grid-column-full">
-        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
-      </div>
-
-      <div class="govuk-grid-column-two-thirds-from-desktop">
-        <h2 id="govuk-support" class="govuk-heading-l">GOV.UK Design System</h2>
-        <p class="govuk-body">The Claim additional payments for teaching design patterns was forked from the GOV.UK Design System.</p>
         <p class="govuk-body">
-          The GOV.UK Design System is <a class="govuk-link" href="/design-system-team">maintained by a team at the Government Digital Service</a>.
-          If you’ve got a question, idea or suggestion you can:
+          This service began it's life in early 2019 and the design team left the
+          project in April 2020. The team consited of civil servants based in the
+          Financial Incentives team in Manchester, Paper and dxw.
         </p>
+
+        <p class="govuk-body">
+          If you have a question about Claim additional payments for teaching you can:
+        </p>
+
         <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
-        <li>
-          email
-          <a href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" class="govuk-link" data-hsupport="email">
-            govuk-design-system-support@digital.cabinet-office.gov.uk
-          </a>
-        </li>
-        <li>
-          get in touch using the
-          <a href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system" class="govuk-link" data-hsupport="slack">
-            #govuk-design-system channel on cross-government Slack</a>
-        </li>
+          <li>
+            email
+            <a href="mailto:additionalteachingpayment@digital.education.gov.uk" class="govuk-link" data-hsupport="email">additionalteachingpayment@digital.education.gov.uk</a>
+          </li>
+          <li>
+            get in touch using the
+            <a href="https://ukgovernmentdfe.slack.com/app_redirect?channel=twd_claim_payments" class="govuk-link" data-hsupport="slack">
+              #twd_claim_payments channel on DfE Slack</a>
+          </li>
+          <li>
+            contact Paper (service design and research) by <a href="https://paper.studio/contact" class="govuk-link">emailing them</a>
+          </li>
+          <li>
+            contact dxw (interaction design and development) by <a href="https://www.dxw.com/contact/" class="govuk-link">emailing them</a>
+          </li>
+          </ul>
+        </div>
+
+        <div class="govuk-grid-column-full">
+          <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+        </div>
+
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+          <h2 id="govuk-support" class="govuk-heading-l">GOV.UK Design System</h2>
+          <p class="govuk-body">The Claim additional payments for teaching design patterns was forked from the GOV.UK Design System.</p>
+          <p class="govuk-body">
+            The GOV.UK Design System is <a class="govuk-link" href="/design-system-team">maintained by a team at the Government Digital Service</a>.
+            If you’ve got a question, idea or suggestion you can:
+          </p>
+          <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+          <li>
+            email
+            <a href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" class="govuk-link" data-hsupport="email">
+              govuk-design-system-support@digital.cabinet-office.gov.uk
+            </a>
+          </li>
+          <li>
+            get in touch using the
+            <a href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system" class="govuk-link" data-hsupport="slack">
+              #govuk-design-system channel on cross-government Slack</a>
+          </li>
         </ul>
       </div>
 


### PR DESCRIPTION
As we currently do not have styles or components pages, the links have been removed from the index. 