### PR TITLE
Fixes to patterns page

### DIFF
--- a/src/patterns/index.md.njk
+++ b/src/patterns/index.md.njk
@@ -5,8 +5,11 @@ description: Patterns are best practice design solutions for specific user-focus
 show_subnav: true
 ---
 
-Patterns are best practice design solutions for specific user-focused tasks and page&nbsp;types.
+Patterns are best practice design solutions for specific user-focused tasks and
+page types.
 
-All of the patterns in this section are supported by written guidance and contain coded examples where possible.
+All of the patterns in this section are supported by written guidance and
+contain coded examples where possible.
 
-Patterns often use one or more [components](../components) and explain how to adapt them to the&nbsp;context.
+Patterns often use one or more [components](https://design-system.service.gov.uk/components/)
+from the GOV.UK design system and explain how to adapt them to the context.


### PR DESCRIPTION
- components link now points to design system components
- explicitly reference GOV.UK components as we do not want to duplicate
  their work
- improve code formatting
- remove extraneous html characters