### PR TITLE
Pre 1.0 pass

### DIFF
--- a/src/community/propose-a-content-change-using-github/index.md.njk
+++ b/src/community/propose-a-content-change-using-github/index.md.njk
@@ -1,12 +1,12 @@
 ---
 title: Propose a content change using GitHub
-description: Find out how to suggest a change to content in the DfE  Claim additional payments for teaching design system using GitHub
+description: Find out how to suggest a change to content in the DfE Claim additional payments for teaching design system using GitHub
 section: Community
 layout: layout-pane.njk
 order: 2
 ---
 
-The DfE  Claim additional payments for teaching design system team uses a service called GitHub to manage content in the DfE  Claim additional payments for teaching design system.
+The DfE Claim additional payments for teaching design system team uses a service called GitHub to manage content in the DfE  Claim additional payments for teaching design system.
 
 This guide explains how to propose a change to the Design System's content. You'll need a GitHub account to do this.
 
@@ -14,13 +14,22 @@ If you do not have one already, you can [create a GitHub account for free](https
 
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {{ govukInsetText({
-  text: "Rest assured that it's impossible for you to break the Design System by proposing changes. The GOV.UK Design System team reviews all changes before publishing."
+  text: "Rest assured that it's impossible for you to break the Design System by proposing changes. The DfE Claim additional payments for teaching design system team reviews all changes before publishing."
 }) }}
 
 If you get stuck whilst following these steps and you need help, you can:
 
-- get in touch on [#govuk-design-system channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)
-- email the GOV.UK Design System team on <br>govuk-design-system-support@digital.cabinet-office.gov.uk
+<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+  <li>
+    email
+    <a href="mailto:additionalteachingpayment@digital.education.gov.uk" class="govuk-link" data-hsupport="email">additionalteachingpayment@digital.education.gov.uk</a>
+  </li>
+  <li>
+    get in touch using the
+    <a href="https://ukgovernmentdfe.slack.com/app_redirect?channel=twd_claim_payments" class="govuk-link" data-hsupport="slack">
+      #twd_claim_payments channel on DfE Slack</a>
+  </li>
+</ul>
 
 ## 1. Go to the page you want to edit
 

--- a/src/community/propose-a-content-change-using-github/index.md.njk
+++ b/src/community/propose-a-content-change-using-github/index.md.njk
@@ -1,12 +1,12 @@
 ---
 title: Propose a content change using GitHub
-description: Find out how to suggest a change to content in the GOV.UK Design System using GitHub
+description: Find out how to suggest a change to content in the DfE  Claim additional payments for teaching design system using GitHub
 section: Community
 layout: layout-pane.njk
 order: 2
 ---
 
-The GOV.UK Design System team uses a service called GitHub to manage content in the GOV.UK Design System.
+The DfE  Claim additional payments for teaching design system team uses a service called GitHub to manage content in the DfE  Claim additional payments for teaching design system.
 
 This guide explains how to propose a change to the Design System's content. You'll need a GitHub account to do this.
 
@@ -24,23 +24,23 @@ If you get stuck whilst following these steps and you need help, you can:
 
 ## 1. Go to the page you want to edit
 
-At the bottom of every page in the Design System you will find a section called 'Help improve this page'. 
+At the bottom of every page in the Design System you will find a section called 'Help improve this page'.
 
-Follow the link to propose a change to the page. This will take you to the page's Markdown file. 
+Follow the link to propose a change to the page. This will take you to the page's Markdown file.
 
-You might be told you need to fork the Design System repository to make changes. This is nothing to worry about. It just means you're making a copy of the Design System that you can edit. Select "fork this repository and propose changes" to continue. 
+You might be told you need to fork the Design System repository to make changes. This is nothing to worry about. It just means you're making a copy of the Design System that you can edit. Select "fork this repository and propose changes" to continue.
 
 ![](fork-this-repo.png)
 
 ## 2. Edit the page file
 
-Edit the Markdown to make your change. 
+Edit the Markdown to make your change.
 
 Here is an example showing how to update the description of the checkboxes component.
 
 ![The checkboxes description in the file in GitHub with an uppercase C in the word checkboxes](checkboxes-uppercase.png)
 
-In this example, the uppercase ‘C’ on the word ‘Checkbox’ has been changed to lowercase. 
+In this example, the uppercase ‘C’ on the word ‘Checkbox’ has been changed to lowercase.
 
 ![The checkboxes description in the file in GitHub after the C in the word checkboxes has been changed to lowercase](checkboxes-lowercase.png)
 
@@ -48,7 +48,7 @@ In this example, the uppercase ‘C’ on the word ‘Checkbox’ has been chang
 
 Once you’re happy, find the section called 'Propose file change' at the bottom of the page.
 
-Add a short description explaining the reason for your change in the first field. This information will be added to the file’s changelog. Try to be as clear as possible, to help future users understand the update. 
+Add a short description explaining the reason for your change in the first field. This information will be added to the file’s changelog. Try to be as clear as possible, to help future users understand the update.
 
 If you need to provide more information about your change, you can add more detail in the larger field below.
 
@@ -58,9 +58,9 @@ When you are happy with your description, select ‘propose file change’. You'
 
 ## 4. Confirm your changes
 
-You'll be shown a confirmation page where you can review the changes you’ve made. 
+You'll be shown a confirmation page where you can review the changes you’ve made.
 
-If you spot a mistake, you can go back to the previous page and correct it. 
+If you spot a mistake, you can go back to the previous page and correct it.
 
 If you are happy with your changes, select ‘Create pull request’. You'll have one more chance to review your change on the next page before you submit it to the GOV.UK Design System team to review.
 

--- a/src/index.njk
+++ b/src/index.njk
@@ -18,7 +18,7 @@ description: Reuse some patterns from the Claim additional payments for teaching
         </p>
 
         <p class="govuk-body">
-          This service began it's life in early 2019 and the design team left the
+          This service began its life in early 2019 and the design team left the
           project in April 2020. The team consisted of civil servants based in the
           Financial Incentives team in Manchester, Paper and dxw.
         </p>

--- a/src/patterns/right-to-be-informed-consent/index.md.njk
+++ b/src/patterns/right-to-be-informed-consent/index.md.njk
@@ -19,21 +19,3 @@ by the different sections of the service for example eligibility and payment.
 
 It is also good practice to explicitly state what pieces of information will be
 sent to third parties and who those third parties are.
-
-## How it works
-
-### SOME H3
-Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque nibh mauris,
-sollicitudin quis efficitur non, porttitor sit amet massa. Integer tincidunt
-massa venenatis arcu pulvinar molestie.
-
-### Another H3
-This is some new content
-
-## Research on this pattern
-
-Somethings about research on this pattern:
-
-- RESEARCH 1
-- EXAMPLE 2
-- SOMETHING ELSE

--- a/src/patterns/student-loan-amount/index.md.njk
+++ b/src/patterns/student-loan-amount/index.md.njk
@@ -4,7 +4,6 @@ description: Ask users how much student loan they repaid in a given timeframe
 section: Patterns
 theme: Ask users for…
 aliases: loan amount, student loan, loan, amount, student
-backlog_issue_id: 68
 layout: layout-pane.njk
 ---
 

--- a/src/patterns/subject-to-formal-action-for-poor-performance/index.md.njk
+++ b/src/patterns/subject-to-formal-action-for-poor-performance/index.md.njk
@@ -28,7 +28,7 @@ Say ‘Select yes if you are subject to formal action for poor performance at wo
 
 ## Provide more information on the ineligible screen
 
-It's possible that users' disciplinary action will be revoked before the dealine
+It's possible that users' disciplinary action will be revoked before the deadline
 for a service. You should tell users this deadline if your service is not open
 all year round.
 

--- a/src/patterns/teacher-reference-number/index.md.njk
+++ b/src/patterns/teacher-reference-number/index.md.njk
@@ -23,16 +23,16 @@ they qualify. Schools often use this for employment purposes and for recording
 information with the Teacher Pension Service.
 
 Teacher reference numbers contain 7 digits and may also contain a hyphen, a
-forward slash, or be preceeded by the letters <code>RP</code>.
+forward slash, or be preceded by the letters 'RP.
 
 When asking for teacher reference number:
 
 - give advice about where the user can find their teacher reference number
 - allow the user to enter their reference in whichever format is familiar to
 them, for example with or without spaces, a slash, a hyphen, or the letters
-<code>RP</code>
+'RP'
 - do not use the initialism 'TRN', which is commonly used within DfE, instead
-say <code>Teacher reference number</code>
+say 'Teacher reference number'
 
 ### Error messages
 

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -50,18 +50,21 @@
   <p class="govuk-body app-contact-panel__body">
     If you’ve got a question about the GOV.UK Design System you can contact the team:
   </p>
-  <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+ <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
     <li>
-      on
-      <a class="govuk-link app-contact-panel__link" href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system" data-hsupport="slack">
-        #govuk-design-system channel on cross-government Slack
-      </a>
+      email
+      <a href="mailto:additionalteachingpayment@digital.education.gov.uk" class="govuk-link" data-hsupport="email">additionalteachingpayment@digital.education.gov.uk</a>
     </li>
-    <li class="govuk-!-margin-bottom-0">
-      by email at
-      <a class="govuk-link app-contact-panel__link" href="mailto:govuk-design-system-support@digital.cabinet-office.gov.uk" data-hsupport="email">
-        govuk-design-system-support@digital.cabinet-office.gov.uk
-      </a>
+    <li>
+      get in touch using the
+      <a href="https://ukgovernmentdfe.slack.com/app_redirect?channel=twd_claim_payments" class="govuk-link" data-hsupport="slack">
+        #twd_claim_payments channel on DfE Slack</a>
+    </li>
+    <li>
+      contact Paper (service design and research) by <a href="https://paper.studio/contact" class="govuk-link">emailing them</a>
+    </li>
+    <li>
+      contact dxw (interaction design and development) by <a href="https://www.dxw.com/contact/" class="govuk-link">emailing them</a>
     </li>
   </ul>
 </div>

--- a/views/partials/_contact-panel.njk
+++ b/views/partials/_contact-panel.njk
@@ -1,4 +1,4 @@
-{%- set fileEditURL = "https://github.com/alphagov/govuk-design-system/edit/master/src/" + path + "/index.md.njk" -%}
+{%- set fileEditURL = "https://github.com/DFE-Digital/claim-design-system/edit/master/src/" + path + "/index.md.njk" -%}
 {% if section === 'Styles' or section === 'Components' or section === 'Patterns'%}
   <h2 class="govuk-heading-l govuk-!-padding-top-4">Help improve this page</h2>
 
@@ -8,7 +8,7 @@
     </p>
     <ul class="govuk-list govuk-list--bullet">
       <li>
-        <a class="govuk-link app-contact-panel__link" href="https://github.com/alphagov/govuk-design-system-backlog/issues/{{ backlog_issue_id }}">
+        <a class="govuk-link app-contact-panel__link" href="https://github.com/DFE-Digital/claim-design-system/issues/{{ backlog_issue_id }}">
           share research or feedback about
           {% if section === 'Components' or section === 'Patterns' %}
             the


### PR DESCRIPTION
A load of tweaks to tidy things up that we may have missed.

This mostly
- fixes typos
- removes placeholder text
- changes community pages to point people to our design system not the GOV.UK design system
- changes the help/contact info sections to point towards claim people